### PR TITLE
Replace hard coded status bar height value with lookup

### DIFF
--- a/DCModalSegue/DCModalSegue.m
+++ b/DCModalSegue/DCModalSegue.m
@@ -144,8 +144,9 @@
     UIGraphicsEndImageContext();
     
     if ([UIApplication sharedApplication].statusBarHidden == NO) {
+        CGFloat barHeight = [[UIApplication sharedApplication] statusBarFrame].size.height;
         CGFloat scale = [[UIScreen mainScreen] scale];
-        CGRect rect = CGRectMake(0, 20 * scale, view.bounds.size.width * scale, (view.bounds.size.height -20) * scale);
+        CGRect rect = CGRectMake(0, barHeight * scale, view.bounds.size.width * scale, (view.bounds.size.height - barHeight) * scale);
         CGImageRef imageRef = CGImageCreateWithImageInRect(image.CGImage, rect);
         image = [UIImage imageWithCGImage:imageRef scale:image.scale orientation:image.imageOrientation];
     }


### PR DESCRIPTION
On rare occasions the iOS status bar can be 40pts high rather than 20pts (for example, when on a call or recording something with the microphone).

This patch removes the hardcoded 20pt value and replaces it with a `[[UIApplication sharedApplication] statusBarFrame].size.height`. This prevents the animation 'snapping' into place when an extended status bar is present.
