### PR TITLE
Fix ignored completion block on dismiss of view controller

### DIFF
--- a/DCModalSegue/DCModalSegue.m
+++ b/DCModalSegue/DCModalSegue.m
@@ -47,7 +47,7 @@
         // Dismiss the presented / destination controller
         [super dismissViewControllerAnimated:YES completion:^{
             // And then dismiss DCModalViewController
-            [self oldDismissViewControllerAnimated:NO completion:nil];
+            [self oldDismissViewControllerAnimated:NO completion:completion];
         }];
     }];
 }


### PR DESCRIPTION
Previously the completion block was ignored and not called on dismissal
after performing a DCModalSegue.
